### PR TITLE
Use area ent/ext transition code instead of name.

### DIFF
--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/movementrules/service/mapper/MovementFactMapper.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/movementrules/service/mapper/MovementFactMapper.java
@@ -62,13 +62,11 @@ public class MovementFactMapper {
                     fact.getAreaTypes().add(area.getAreaType());
                 }
                 if (MovementTypeType.ENT.equals(area.getTransitionType())) {
-                    fact.getEntAreaCodes().add(area.getName());
-                    fact.getAreaCodes().add(area.getCode());
+                    fact.getEntAreaCodes().add(area.getCode());
                     fact.getEntAreaTypes().add(area.getAreaType());
                 }
                 if (MovementTypeType.EXI.equals(area.getTransitionType())) {
-                    fact.getExtAreaCodes().add(area.getName());
-                    fact.getAreaCodes().add(area.getCode());
+                    fact.getExtAreaCodes().add(area.getCode());
                     fact.getExtAreaTypes().add(area.getAreaType());
                 }
             }


### PR DESCRIPTION
- Add code instead of name for entAreaCodes/extAreaCodes
- Do not add areaCode twice for ENT. Do not add areaCode at all for EXT.